### PR TITLE
Prototype of AST annotations helper

### DIFF
--- a/lib/credo/code/annotate.ex
+++ b/lib/credo/code/annotate.ex
@@ -1,0 +1,53 @@
+defmodule Credo.Code.Annotate do
+
+  def collect_meta(ast) do
+    acc = []
+    {_, acc} = Macro.prewalk(ast, acc, &collect_meta/2)
+    Enum.reverse acc
+  end
+
+  def collect_meta({_op, meta, _args} = ast, acc) do
+    {ast, [meta|acc]}
+  end
+
+  def collect_meta(ast, acc) do
+    {ast, acc}
+  end
+
+  def annotate(ast) do
+    acc = []
+    {ast, _} = Macro.traverse ast, acc, &prewalk/2, &postwalk/2
+    ast
+  end
+
+  def prewalk({:def, _meta, _args} = ast, acc) do
+    ast = update_meta(ast, :syn, :definition)
+    {ast, acc}
+  end
+
+  def prewalk({name, _meta, nil} = ast, acc) when is_atom(name) do
+    ast = update_meta(ast, :syn, :variable)
+    {ast, acc}
+  end
+
+  def prewalk({name, _meta, args} = ast, acc) when is_atom(name) and is_list(args) do
+    ast = update_meta(ast, :syn, :call)
+    {ast, acc}
+  end  
+
+  def prewalk(ast, acc) do
+    {ast, acc}
+  end
+
+  def postwalk(ast, acc) do
+    {ast, acc}
+  end
+
+  def update_meta(ast, key, value) do
+    case ast do
+      {op, meta, args} ->
+        {op, Keyword.put(meta, key, value), args}
+      _ -> ast
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,8 @@ defmodule Credo.Mixfile do
       {:bunt, "~> 0.2.0"},
       {:jason, "~> 1.0"},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
-      {:inch_ex, "~> 0.1", only: [:dev, :test], runtime: false}
+      {:inch_ex, "~> 0.1", only: [:dev, :test], runtime: false},
+      {:mix_test_watch, "~> 0.8", only: :dev, runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -2,10 +2,12 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.9.0", "c72132a6071261893518fa08e121e911c9358713f62794a90c95db59042af375", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }

--- a/test/credo/code/annotate_test.exs
+++ b/test/credo/code/annotate_test.exs
@@ -1,0 +1,21 @@
+defmodule Credo.Code.AnnotateTest do
+  use Credo.TestHelper
+
+  alias Credo.Code.Annotate
+
+  test "it should" do
+    source = """
+    def foo(a, b) do
+      a + b
+    end
+    """
+
+    ast = Code.string_to_quoted! source
+    ast = Annotate.annotate ast
+    meta = Annotate.collect_meta ast
+    syn = Enum.map(meta, &Keyword.get(&1, :syn))
+
+    assert syn == [:definition, :call, :variable, :variable, :call, :variable, :variable]
+
+  end
+end


### PR DESCRIPTION
This code could make it easier to implement things like the ABC
by giving a reusable way of annotation the AST with more information.

Also, the annotations in the AST could be used for educational purposes
-- to show the developer what each part of the AST means when for
example the ABC check triggers.